### PR TITLE
Fix for the submodule inclusion

### DIFF
--- a/govuk_frontend_toolkit.gemspec
+++ b/govuk_frontend_toolkit.gemspec
@@ -18,33 +18,19 @@ Gem::Specification.new do |s|
   s.add_development_dependency "gemfury", "0.4.12"
 
   s.require_paths = ["lib", "app"]
-  s.files         = `git ls-files`.split($\)
+  s.files         = `git ls-files`.split("\n")
 
-  # We need to include the files from the submodules, example from:
-  # http://somethingaboutcode.wordpress.com/2012/09/27/include-files-from-git-submodules-when-building-a-ruby-gem/
+  `git submodule init`
+  `git submodule update`
 
-  gemroot_path = `pwd`.strip
-  # get an array of submodule dirs by executing 'pwd' inside each submodule
-  `git submodule --quiet foreach pwd`.split($\).each do |submodule_path|
-    # for each submodule, change working directory to that submodule
+  `git submodule foreach`.split("\n").each do |line|
+    submodule_path = line.split[1].gsub('\'', '')
+
     Dir.chdir(submodule_path) do
-
-      # issue git ls-files in submodule's directory
-      submodule_files = `git ls-files`.split($\)
-
-      # prepend the submodule path to create absolute file paths
-      submodule_files_fullpaths = submodule_files.map do |filename|
-        "#{submodule_path}/#{filename}"
+      unwanted = ["jenkins.sh"]
+      (`git ls-files`.split("\n") - unwanted).each do |submodule_file|
+        s.files << "#{submodule_path}/#{submodule_file}"
       end
-
-      # remove leading path parts to get paths relative to the gem's root dir
-      # (this assumes, that the gemspec resides in the gem's root dir)
-      submodule_files_paths = submodule_files_fullpaths.map do |filename|
-        filename.gsub "#{gemroot_path}/", ""
-      end
-
-      # add relative paths to gem.files
-      s.files += submodule_files_paths
     end
   end
 end


### PR DESCRIPTION
Hello,

The problem this PR solves is the issue @teneightfive experienced when using your gem:

the files of the submodule of the gem weren't being included. 

This can be proved by the following steps:

```
$ git clone git@github.com:alphagov/govuk_frontend_toolkit_gem.git
$ cd govuk_frontend_toolkit_gem
$ gem build govuk_frontend_toolkit.gemspec 
$ mv govuk_frontend_toolkit-0.39.0.gem del
$ cd del
$ tar xvf govuk_frontend_toolkit-0.39.0.gem
x metadata.gz
x data.tar.gz
x checksums.yaml.gz
$ tar zxvf data.tar.gz 
x .gitignore
x .gitmodules
x CONTRIBUTING.md
x Gemfile
x LICENCE
x README.md
x Rakefile
x govuk_frontend_toolkit.gemspec
x jenkins.sh
x lib/govuk_frontend_toolkit.rb
x lib/govuk_frontend_toolkit/engine.rb
x lib/govuk_frontend_toolkit/version.rb
```

at this point you should not see any files under **app/assets**.

Due to this we've experienced build failures with our app. Please see:

https://travis-ci.org/ministryofjustice/opg-lpa/builds/16535855

(it's failing since it can't find **colours.scss** file, see line _1212_).

Once our patch was added: 

https://github.com/ministryofjustice/opg-lpa/commit/d65b317f849919f2a8ed8017d60e99d774d69117

the build passed:

https://travis-ci.org/ministryofjustice/opg-lpa/builds/16581101

Please consider merging this into your gem.
