### PR TITLE
Change README to include notes on using submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Just include `govuk_frontend_toolkit` in your `Gemfile`. It
 automatically attaches itself to your asset path so the static/SCSS
 files will be available to the asset pipeline.
 
+### Development
+
+If you are installing from git, ensure you enable submodules like so:
+
+    gem 'govuk_frontend_toolkit', :git => "https://github.com/alphagov/govuk_frontend_toolkit_gem.git", :submodules => true
+
 You will need to check that the gem is included while in development. Often
 asset related gems are in a bundler group called `assets`. Old Rails projects
 do not inluded this in development by default so you need to ensure bundler is
@@ -20,7 +26,9 @@ included using the following lines at the top of the `/config/application.rb`:
       # Bundler.require(:default, :assets, Rails.env)
     end
 
-You will also need to ensure that the correct assets are precompiled for
+### Production
+
+You will need to ensure that the correct assets are precompiled for
 production. These are set using the variable `config.assets.precompile` in
 `/config/application.rb`. An example of what this may look like is:
 


### PR DESCRIPTION
Specifically when used with [Bundler](http://bundler.io/).

Based on work done by @james on https://github.com/alphagov/govuk_frontend_toolkit_gem/pull/4
