### PR TITLE
Avoid actioncable dependency on Rails 5

### DIFF
--- a/govuk_frontend_toolkit.gemspec
+++ b/govuk_frontend_toolkit.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |s|
   s.homepage     = 'https://github.com/alphagov/govuk_frontend_toolkit'
   s.license      = 'MIT'
 
-  s.add_dependency "rails", ">= 3.1.0"
+  s.add_dependency "railties", ">= 3.1.0"
+
   s.add_dependency "sass", ">= 3.2.0"
   s.add_development_dependency "rake", "0.9.2.2"
 


### PR DESCRIPTION
Specify single rails gems dependencies to avoid to include actioncable.
It has a security vulnerability which prevents `smart-answers`, which
rely on govuk_frontend_toolkit, to upgrade to rails 5.

related to PR: https://github.com/alphagov/smart-answers/pull/3054
Trello: https://trello.com/c/yKUuy2VI/635-migrate-to-rails-5%3A-smart-answers 